### PR TITLE
DPI-2910 Package flipStartup in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,21 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "flipStartup";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''Various analytics to assist in the analysis of the performance of startups.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    flipTime
+    flipStandardCharts
+    flipU
+    scales
+    lubridate
+    reshape2
+    verbs
+    plotly
+    flipFormat
+    flipStatistics
+    ggplot2
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package flipStartup in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR